### PR TITLE
use AndroidX with 29 API to prevent build failures

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "co.appbrewery.destinichallengestarting"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.0.0-alpha08'
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx700M
+android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-2-all.zip


### PR DESCRIPTION
Almost all face the problem after cloning the repo which is not using AndroidX and 27 API on latest Flutter release
More details of issue here https://stackoverflow.com/questions/59481062/flutter-on-android-studio-cloning-from-git-problem-package-get-has-not-been-ru